### PR TITLE
Include required UID key in Opauth response

### DIFF
--- a/EvernoteStrategy.php
+++ b/EvernoteStrategy.php
@@ -146,6 +146,7 @@ class EvernoteStrategy extends OpauthStrategy
 
             if ($results !== false && !empty($results['oauth_token'])) {
                 $this->auth = array(
+                    'uid' => $results['edam_userId'],
                     'credentials' => array(
                         'token' => $results['oauth_token'],
                         'secret' => $results['oauth_token_secret']


### PR DESCRIPTION
Fixes critical issue with #5 (still missing name, but API response doesn't contain this information)